### PR TITLE
fixed 1d location subsetting in obs_sequence_tool

### DIFF
--- a/assimilation_code/programs/obs_sequence_tool/obs_sequence_tool.f90
+++ b/assimilation_code/programs/obs_sequence_tool/obs_sequence_tool.f90
@@ -221,13 +221,13 @@ if (num_FO_types_to_suppress > 0) call setup_FO_suppress_list(FO_write_types)
 ! the values if so.  Note that if any of the values are not missing_r8, all of
 ! them must have good (and consistent) values.  i don't have code in here yet
 ! to idiotproof this, but i should add it.
+
+restrict_by_location = .false.
 if ((minval(min_box).ne.missing_r8) .or. (maxval(min_box).ne.missing_r8) .or. &
     (minval(max_box).ne.missing_r8) .or. (maxval(max_box).ne.missing_r8)) then
    restrict_by_location = .true.
    min_loc = set_location(min_box)
    max_loc = set_location(max_box)
-else
-   restrict_by_location = .false.
 endif
 
 ! 3d sphere box check - locations module dependent, but an important one.
@@ -302,8 +302,6 @@ if ((min_lat /= -90.0_r8) .or. (max_lat /=  90.0_r8) .or. &
    max_box(3) = 0.0_r8
    max_box(4) = -2.0_r8 !! FIXME: VERTISUNDEF, but not all loc mods have it
    max_loc = set_location(max_box)
-else
-   restrict_by_location = .false.
 endif
   
 !%! ! SPECIAL: cut off all GPS obs below the given height


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 
modified obs_sequence_tool.f90 to fix location subsetting on 1D domains, which previously was not functioning.

### Fixes issue
<!--- link to github issue(s) -->
https://github.com/NCAR/DART/issues/547

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

rebuilt and ran obs_sequence_tool on a sample obs sequence file. 1D location trimming works as expected.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x ] No dataset needed
